### PR TITLE
fix:improve dev start script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,8 +44,6 @@
         "fs-extra": "^10.1.0",
         "nodemon": "^2.0.19",
         "npm-run-all": "^4.1.5",
-        "rimraf": "^3.0.2",
-        "shelljs": "^0.8.5",
         "ts-node": "^10.9.1",
         "typescript": "^4.8.2"
       }
@@ -3104,15 +3102,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/interpret": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/ip": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
@@ -4619,18 +4608,6 @@
         "node": ">=8.10.0"
       }
     },
-    "node_modules/rechoir": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
-      "dev": true,
-      "dependencies": {
-        "resolve": "^1.1.6"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
@@ -4980,23 +4957,6 @@
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
       "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==",
       "dev": true
-    },
-    "node_modules/shelljs": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
-      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
-      },
-      "bin": {
-        "shjs": "bin/shjs"
-      },
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/side-channel": {
       "version": "1.0.4",
@@ -8262,12 +8222,6 @@
         "side-channel": "^1.0.4"
       }
     },
-    "interpret": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
-      "dev": true
-    },
     "ip": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
@@ -9369,15 +9323,6 @@
         "picomatch": "^2.2.1"
       }
     },
-    "rechoir": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
-      "dev": true,
-      "requires": {
-        "resolve": "^1.1.6"
-      }
-    },
     "regexp.prototype.flags": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
@@ -9602,17 +9547,6 @@
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
       "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==",
       "dev": true
-    },
-    "shelljs": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
-      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
-      "dev": true,
-      "requires": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
-      }
     },
     "side-channel": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -3,13 +3,9 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "clean": "rimraf dist/*",
     "lint": "eslint . --ext .ts",
-    "tsc": "tsc",
-    "copy-assets": "ts-node tools/copyAssets",
-    "start": "node ./dist/bin/www",
-    "build": "npm-run-all clean lint tsc copy-assets",
-    "dev:start": "npm-run-all build start",
+    "start": "ts-node ./src/bin/www",
+    "dev:start": "npm-run-all lint start",
     "dev": "nodemon --watch src -e ts,css --exec npm run dev:start"
   },
   "dependencies": {
@@ -49,8 +45,6 @@
     "fs-extra": "^10.1.0",
     "nodemon": "^2.0.19",
     "npm-run-all": "^4.1.5",
-    "rimraf": "^3.0.2",
-    "shelljs": "^0.8.5",
     "ts-node": "^10.9.1",
     "typescript": "^4.8.2"
   }

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,4 @@
-import { config } from "./config.js";
+import { config } from "./config";
 import { sequelize } from "./database";
 
 import createError from 'http-errors';

--- a/src/bin/www.ts
+++ b/src/bin/www.ts
@@ -9,7 +9,7 @@ import {app} from "../app";
 import Debug from 'debug';
 const debug = Debug('cmpmp-backend:server');
 import * as http from 'http';
-import {config} from "../config.js";
+import {config} from "../config";
 import { AddressInfo } from "net";
 
 /**

--- a/tools/copyAssets.ts
+++ b/tools/copyAssets.ts
@@ -1,6 +1,0 @@
-import * as shell from "shelljs";
-
-// Copy all the view templates
-shell.cp( "-R", "src/views", "dist/" );
-// Copy all the public files
-shell.cp( "-R", "src/public", "dist/" );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
     /* Type Checking */
     "strict": true,                                      /* Enable all strict type-checking options. */
     /* Completeness */
-    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+    "skipLibCheck": true,                                 /* Skip type checking all .d.ts files. */
+    "typeRoots" : ["./src/typings"]
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
No longer explicitly transpiling TypeScript into ./dist and instead sing ts-node to run the app. This removes the need to cleaning the ./dist folder and copying assets, removing devDeps for shelljs and rimraf. This should improve startup times, and reduce waiting when nodemon picks up changes